### PR TITLE
Add support for Active MQ Failover URLs

### DIFF
--- a/chart/account/templates/deployment.yaml
+++ b/chart/account/templates/deployment.yaml
@@ -66,6 +66,11 @@ spec:
               secretKeyRef:
                 name: mq
                 key: pwd
+          - name: MQ_URL
+            valueFrom:
+              secretKeyRef:
+                name: mq
+                key: url
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/manifests/demodeploy.yaml
+++ b/manifests/demodeploy.yaml
@@ -71,6 +71,11 @@ spec:
               secretKeyRef:
                 name: mq   
                 key: pwd
+          - name: MQ_URL
+            valueFrom:
+              secretKeyRef:
+                name: mq
+                key: url
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/manifests/deploy-openshift.yaml
+++ b/manifests/deploy-openshift.yaml
@@ -83,6 +83,11 @@ spec:
               secretKeyRef:
                 name: mq
                 key: pwd
+          - name: MQ_URL
+            valueFrom:
+              secretKeyRef:
+                name: mq
+                key: url
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/manifests/deploy.yaml
+++ b/manifests/deploy.yaml
@@ -76,6 +76,11 @@ spec:
               secretKeyRef:
                 name: mq   
                 key: pwd
+          - name: MQ_URL
+            valueFrom:
+              secretKeyRef:
+                name: mq
+                key: url
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/manifests/portfolio-values.yaml
+++ b/manifests/portfolio-values.yaml
@@ -60,6 +60,11 @@ image:
         secretKeyRef:
           name: mq   
           key: pwd
+    - name: MQ_URL
+      valueFrom:
+        secretKeyRef:
+          name: mq
+          key: url
     - name: MQ_HOST
       valueFrom:
         secretKeyRef:

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountService.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountService.java
@@ -60,6 +60,8 @@ import org.eclipse.microprofile.opentracing.Traced;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 //Servlet 4.0
+import javax.jms.Queue;
+import javax.jms.QueueConnectionFactory;
 import javax.servlet.http.HttpServletRequest;
 
 //JAX-RS 2.1 (JSR 339)
@@ -101,7 +103,14 @@ public class AccountService extends Application {
 
 	@Resource(lookup="cloudant/AccountDB") Database accountDB;  //defined in the server.xml
 
-	private AccountUtilities utilities = new AccountUtilities();
+	// For some reason, for these injections to work, they must be declared static and be located in this class
+	// not AccountUtilities. If you remove the static keyword the injection fails.
+	@Resource(lookup = "jms/Portfolio/NotificationQueue")
+	private static Queue queue;
+	@Resource(lookup = "jms/Portfolio/NotificationQueueConnectionFactory")
+	private static QueueConnectionFactory queueCF;
+
+	private AccountUtilities utilities = new AccountUtilities(queueCF, queue);
 
 	private @Inject @RestClient ODMClient odmClient;
 	private @Inject @RestClient WatsonClient watsonClient;

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountUtilities.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountUtilities.java
@@ -76,15 +76,18 @@ public class AccountUtilities {
 	private static final String GOLD     = "Gold";
 	private static final String PLATINUM = "Platinum";
 
-	@Resource(lookup = "jms/Portfolio/NotificationQueue")
-	private static Queue queue;
-	@Resource(lookup = "jms/Portfolio/NotificationQueueConnectionFactory")
-	private static QueueConnectionFactory queueCF;
+	private Queue queue;
+	private QueueConnectionFactory queueCF;
 
 	private static SimpleDateFormat timestampFormatter = null;
 
 	private static final String mqId = System.getenv("MQ_ID");
 	private static final String mqPwd = System.getenv("MQ_PASSWORD");
+
+	public AccountUtilities(QueueConnectionFactory queueCF, Queue queue){
+		this.queueCF = queueCF;
+		this.queue = queue;
+	}
 
 	@Traced
 	String invokeODM(ODMClient odmClient, String odmId, String odmPwd, String owner, double overallTotal, String oldLoyalty, HttpServletRequest request) {

--- a/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
+++ b/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
@@ -2,11 +2,13 @@
     <authData id="MQ-Credentials" user="${env.MQ_ID}" password="${env.MQ_PASSWORD}"></authData>
 
     <resourceAdapter id="activemq" location="/config/activemq.rar">
+        <properties.activemq ServerUrl="${env.MQ_URL}" />
         <classloader apiTypeVisibility="+third-party"/>
     </resourceAdapter>
 
     <jmsQueueConnectionFactory id="NotificationQCF" jndiName="jms/Portfolio/NotificationQueueConnectionFactory" containerAuthDataRef="MQ-Credentials">
-        <properties.activemq ServerUrl="ssl://${env.MQ_HOST}"/>
+        <properties.activemq ServerUrl="${env.MQ_URL}" />
+<!--        <properties.activemq ServerUrl="${env.MQ_URL}"/>-->
         <!-- Using .activemq as that is the ID for the resource adapter          -->
         <!-- ******************************************************************* -->
         <!-- Note, that this is the OpenWire endpoint (ssl://)                   -->

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -29,6 +29,7 @@
     <variable name="AUTH_TYPE" defaultValue="basic"/>
     <variable name="CLOUDANT_TYPE" defaultValue="cloudant"/>
     <variable name="TRACE_SPEC" defaultValue="*=info"/>
+    <variable name="MQ_URL" defaultValue="ssl://${MQ_HOST}:${MQ_PORT}"/>
 
     <logging traceSpecification="${TRACE_SPEC}" consoleLogLevel="INFO" />
 


### PR DESCRIPTION
This PR adds support for Active MQ failover URLs. This allows us to use highly-available brokers.

The parent PR which adds this support to the operator is: https://github.com/IBMStockTrader/stocktrader-operator/pull/9
