### PR TITLE
Switch to JNoSQL draft Jakarta EE Spec from Cloudant API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,14 @@
     <app.name>account</app.name>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.release>21</maven.compiler.release>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.6.1</quarkus.platform.version>
+    <jnosql.version>1.0.3</jnosql.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <warContext>${app.name}</warContext>
@@ -82,6 +85,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
+    <!-- Used for metric collection since Quarkus doesn't support OTEL Metrics (yet) -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-micrometer</artifactId>
@@ -132,6 +136,23 @@
       <version>2.2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jnosql.databases</groupId>
+      <artifactId>jnosql-couchdb</artifactId>
+      <version>${jnosql.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jnosql.mapping</groupId>
+          <artifactId>jnosql-mapping-reflection</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jnosql.lite</groupId>
+      <artifactId>mapping-lite-processor</artifactId>
+      <version>${jnosql.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-docker</artifactId>
     </dependency>
@@ -144,41 +165,6 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.cloudant</groupId>
-      <artifactId>cloudant-client</artifactId>
-      <version>2.20.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.cloudant</groupId>
-      <artifactId>cloudant-http</artifactId>
-      <version>2.20.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp-urlconnection</artifactId>
-      <version>4.10.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.thrift</groupId>
-      <artifactId>libthrift</artifactId>
-      <version>0.18.1</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -102,9 +102,12 @@ COPY --chown=185 target/quarkus-app/*.jar /deployments/
 COPY --chown=185 target/quarkus-app/app/ /deployments/app/
 COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
-# Debug options. Uncomment these two lines and comment down the matching lines below
+# Debug options. Uncomment these four lines and comment down the matching lines below
 #EXPOSE 9080 5005
-#ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -e JAVA_DEBUG=true -e JAVA_DEBUG_PORT=*:5005"
+#ENV JAVA_DEBUG=true
+#ENV JAVA_DEBUG_PORT=*:5005
+#ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
 
 # Default Runtime options
 EXPOSE 9080

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountService.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountService.java
@@ -86,10 +86,10 @@ public class AccountService {
     @ConfigProperty(name = "watson.id", defaultValue = "apikey") String watsonId;
     @ConfigProperty(name = "watson.pwd") String watsonPwd; //if using an API Key, it goes here
 
-//    @Inject
-//    public AccountService(AccountRepository accountDbRepository){
-//        this.accountDbRepository=accountDbRepository;
-//    }
+    @Inject
+    public AccountService(AccountRepository accountDbRepository){
+        this.accountDbRepository=accountDbRepository;
+    }
 
 
     // Injection/initialization takes place after the class is instantiated, so we create the connection to CouchDB/Cloudant

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountService.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/AccountService.java
@@ -17,14 +17,9 @@
 
 package com.ibm.hybrid.cloud.sample.stocktrader.account;
 
-import com.cloudant.client.api.ClientBuilder;
-import com.cloudant.client.api.CloudantClient;
-import com.cloudant.client.api.Database;
-import com.cloudant.client.api.model.Response;
-import com.cloudant.client.org.lightcouch.DocumentConflictException;
-import com.cloudant.client.org.lightcouch.NoDocumentException;
 import com.ibm.hybrid.cloud.sample.stocktrader.account.client.ODMClient;
 import com.ibm.hybrid.cloud.sample.stocktrader.account.client.WatsonClient;
+import com.ibm.hybrid.cloud.sample.stocktrader.account.db.AccountRepository;
 import com.ibm.hybrid.cloud.sample.stocktrader.account.json.Account;
 import com.ibm.hybrid.cloud.sample.stocktrader.account.json.Feedback;
 import com.ibm.hybrid.cloud.sample.stocktrader.account.json.WatsonInput;
@@ -41,23 +36,20 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-//@ApplicationPath("/")
-@Path("/account")
-@LoginConfig(authMethod = "MP-JWT", realmName = "jwt-jaspi")
-//@RequestScoped //enable interceptors (note you need a WEB-INF/beans.xml in your war)
 /** This microservice takes care of non-stock related attributes of a customer's account.  This includes
  *  commissions, account balance, sentiment, free trades, and loyalty level determination.  This version
  *  persists data to a CouchDB-derived non-SQL datastore.
  */
+@Path("/account")
+@LoginConfig(authMethod = "MP-JWT", realmName = "jwt-jaspi")
+//@RequestScoped //enable interceptors (note you need a WEB-INF/beans.xml in your war)
 @ApplicationScoped
 public class AccountService {
     private static final Logger logger = Logger.getLogger(AccountService.class.getName());
@@ -78,8 +70,7 @@ public class AccountService {
 
     private boolean delayUpdate = false;
 
-    Database accountDB;
-    CloudantClient cloudantClient;
+    private final AccountRepository accountDbRepository;
 
     private int basic = 0, bronze = 0, silver = 0, gold = 0, platinum = 0, unknown = 0; //loyalty level counts
 
@@ -95,37 +86,29 @@ public class AccountService {
     @ConfigProperty(name = "watson.id", defaultValue = "apikey") String watsonId;
     @ConfigProperty(name = "watson.pwd") String watsonPwd; //if using an API Key, it goes here
 
-    @ConfigProperty(name = "cloudant.url") String cloudantUrl;
-    @ConfigProperty(name = "cloudant.id") String cloudantId;
-    @ConfigProperty(name = "cloudant.password") String cloudantPassword;
-    @ConfigProperty(name = "cloudant.db") String cloudantDb;
+//    @Inject
+//    public AccountService(AccountRepository accountDbRepository){
+//        this.accountDbRepository=accountDbRepository;
+//    }
 
 
     // Injection/initialization takes place after the class is instantiated, so we create the connection to CouchDB/Cloudant
     // afterward the no-arg constructor is called.
     //	https://stackoverflow.com/questions/3406555/why-use-postconstruct#3406631
     @PostConstruct
-    public void postConstruct() throws MalformedURLException {
-        logger.fine("Constructing Cloudant/Couch Client");
-        if (this.cloudantClient == null) {
+    public void postConstruct() {
+        logger.fine("Constructing Watson and ODM Clients");
             synchronized (this) {
-                cloudantClient = ClientBuilder.url(new URL(cloudantUrl))
-                        .username(cloudantId)
-                        .password(cloudantPassword)
-                        .build();
-                accountDB = cloudantClient.database(cloudantDb, true);
+            if (watsonClient != null) {
+                logger.info("Watson initialization completed successfully!");
+            } else {
+                logger.warning("WATSON config properties are unset");
+            }
 
-                if (watsonClient != null) {
-                    logger.info("Watson initialization completed successfully!");
-                } else {
-                    logger.warning("WATSON config properties are unset");
-                }
-
-                if (odmClient != null) {
-                    logger.info("ODM initialization complete");
-                } else {
-                    logger.warning("ODM config properties are unset");
-                }
+            if (odmClient != null) {
+                logger.info("ODM initialization complete");
+            } else {
+                logger.warning("ODM config properties are unset");
             }
         }
     }
@@ -135,24 +118,30 @@ public class AccountService {
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed({"StockTrader", "StockViewer"})
     //Couldn't get this to work; had to do it through the web.xml instead :(
-    public List<Account> getAccounts() throws IOException {
+    public List<Account> getAccounts() {
         List<Account> accountList = null;
         int size = 0;
 
         try {
             logger.fine("Entering getAccounts");
-            if (accountDB != null) {
-                accountList = accountDB.getAllDocsRequestBuilder().includeDocs(true).build().getResponse().getDocsAs(Account.class);
+            if (accountDbRepository != null) {
+                accountList = accountDbRepository.findAll().toList();
                 size = accountList.size();
             } else {
-                logger.warning("accountDB is null, so returning empty array.  Investigate why the CDI injection failed for details");
+                logger.warning("accountDbRepository is null, so returning empty array.  Investigate why the CDI injection failed for details");
             }
         } catch (Throwable t) {
             logger.warning("Failure getting accounts");
             logException(t);
         }
 
-        logger.fine("Returning " + size + " accounts");
+        logger.fine("Returning "+size+" accounts");
+        if (logger.isLoggable(Level.FINE)){
+            for (int index=0; index<size; index++) {
+                Account account = accountList.get(index);
+                logger.fine("account["+index+"]="+account);
+            }
+        }
 
 /* Commenting out until https://github.com/OpenLiberty/open-liberty/issues/22592 is addressed
 		try {
@@ -184,38 +173,40 @@ public class AccountService {
 //	@Counted(name="accounts", description="Number of accounts created in the Stock Trader application")
     @RolesAllowed({"StockTrader"}) //Couldn't get this to work; had to do it through the web.xml instead :(
     public Account createAccount(@PathParam("owner") String owner) {
-        Account account = null;
+        Account account;
         if (owner != null) try {
             if (owner.equalsIgnoreCase(FAIL)) {
                 logger.warning("Throwing a 400 error for owner: " + owner);
                 throw new BadRequestException("Invalid value for account owner: " + owner);
             }
 
+            boolean ownerExistInRepo = accountDbRepository.findByOwner(owner).findFirst().isPresent();
+            if(ownerExistInRepo){
+                logger.warning("Account already exists for: " + owner);
+                throw new WebApplicationException("Account already exists for "+owner+"!", CONFLICT);
+            }
+
             //loyalty="Basic", balance=50.0, commissions=0.0, free=0, sentiment="Unknown", nextCommission=9.99
-            account = new Account(owner, "Basic", 50.0, 0.0, 0, "Unknown", 9.99);
+            account = new Account(owner);
 
             logger.fine("Creating account for " + owner);
 
-            Response response = accountDB.save(account);
-            if (response != null) {
-                String id = response.getId();
-                account.set_id(id);
+            account = accountDbRepository.save(account);
+            if (account != null) {
+                String id = account.getId();
                 logger.fine("Created new account for " + owner + " with id " + id);
             } else {
-                logger.warning("Failed to get response from accountDB.save()"); //shouldn't get here - exception should have been thrown if the save failed
+                logger.warning("Failed to get response from accountDbRepository.save()"); //shouldn't get here - exception should have been thrown if the save failed
             }
-
             logger.fine("Account created successfully: " + owner);
-        } catch (DocumentConflictException conflict) {
-            logger.warning("Account already exists for: " + owner);
-            logException(conflict);
-            throw new WebApplicationException("Account already exists for " + owner + "!", CONFLICT);
         } catch (Throwable t) {
             logger.warning("Failure to create account for " + owner);
             logException(t);
+            account=null;
         }
         else {
             logger.warning("Owner is null in createAccount");
+            account = null;
         }
 
         return account;
@@ -226,12 +217,14 @@ public class AccountService {
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed({"StockTrader", "StockViewer"})
     //Couldn't get this to work; had to do it through the web.xml instead :(
-    public Account getAccount(@PathParam("id") String id, @QueryParam("total") double total) throws IOException {
+    public Account getAccount(@PathParam("id") String id, @QueryParam("total") double total) {
+        Optional<Account> accountOptional;
         Account account = null;
         logger.fine("Entering getAccount");
         try {
-            account = accountDB.find(Account.class, id);
-            if (account != null) {
+            accountOptional = accountDbRepository.findById(id);
+            if (accountOptional.isPresent()) {
+                account = accountOptional.get();
                 if (total == DONT_RECALCULATE) {
                     logger.fine("Skipping recalculation of loyalty level and next commission as requested");
                 } else {
@@ -241,15 +234,15 @@ public class AccountService {
                     logger.fine("Invoking external business rule for " + id);
                     //this can be a call to either IBM ODM, or my simple Lambda function alternative, depending on the URL configured in the CR yaml
                     String loyalty = utilities.invokeODM(odmClient, odmId, odmPwd, owner, total, oldLoyalty, jwt.getName());
-                    if ((loyalty != null) && !loyalty.equalsIgnoreCase(oldLoyalty)) { //don't rev the Cloudant doc if nothing's changed
+                    if ((loyalty != null) && !loyalty.equalsIgnoreCase(oldLoyalty)) { //don't rev the doc if nothing's changed
                         account.setLoyalty(loyalty);
 
                         int free = account.getFree();
                         account.setNextCommission(free > 0 ? 0.0 : utilities.getCommission(loyalty));
 
                         if (!delayUpdate) { //if called from updateAccount, let it drive the update to Cloudant
-                            logger.fine("Calling accountDB.update() for " + id + " in getAccount due to new loyalty level");
-                            accountDB.update(account);
+                            logger.fine("Calling repository.save(account) for "+id+" in getAccount due to new loyalty level");
+                            accountDbRepository.save(account);
                         }
                     }
                 }
@@ -258,9 +251,6 @@ public class AccountService {
             } else {
                 logger.warning("Got null in getAccount for " + id + ", rather than expected NoDocumentException");
             }
-        } catch (NoDocumentException t) {
-            logger.warning("Unable to find account for " + id);
-            logException(t);
         } catch (Throwable t) {
             logger.warning("Unknown error finding account for " + id);
             logException(t);
@@ -273,7 +263,7 @@ public class AccountService {
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed({"StockTrader"}) //Couldn't get this to work; had to do it through the web.xml instead :(
-    public Account updateAccount(@PathParam("id") String id, @QueryParam("total") double total) throws IOException {
+    public Account updateAccount(@PathParam("id") String id, @QueryParam("total") double total) {
         logger.fine("Entering updateAccount");
         this.delayUpdate = true;
 
@@ -307,7 +297,7 @@ public class AccountService {
                 }
 
                 logger.fine("Updating account into Cloudant: " + account);
-                accountDB.update(account);
+                accountDbRepository.save(account);
             } else {
                 logger.warning("Account is null for " + id + " in updateAccount");
             }
@@ -324,16 +314,18 @@ public class AccountService {
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed({"StockTrader"}) //Couldn't get this to work; had to do it through the web.xml instead :(
     public Account deleteAccount(@PathParam("id") String id) {
+        Optional<Account> accountOptional;
         Account account = null;
         logger.fine("Entering deleteAccount for " + id);
         try {
-            account = accountDB.find(Account.class, id); //this is sometimes failing with "Error: not_found. Reason: deleted"...
+            accountOptional = accountDbRepository.findById(id);
 
-            if (account != null) {
+            if (accountOptional.isPresent()) {
+                account = accountOptional.get();
                 String owner = account.getOwner();
                 logger.fine("Deleting account for " + owner);
 
-                accountDB.remove(account);
+                accountDbRepository.deleteById(id);
 
                 logger.fine("Successfully deleted account for " + owner); //exception would have been thrown otherwise
             } else {
@@ -352,7 +344,7 @@ public class AccountService {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed({"StockTrader"}) //Couldn't get this to work; had to do it through the web.xml instead :(
-    public Feedback submitFeedback(@PathParam("id") String id, WatsonInput input) throws IOException {
+    public Feedback submitFeedback(@PathParam("id") String id, WatsonInput input) {
         String sentiment = "Unknown";
         Feedback feedback = null;
         try {
@@ -367,6 +359,7 @@ public class AccountService {
 
                 account.setFree(freeTrades);
                 account.setSentiment(feedback.getSentiment());
+                accountDbRepository.save(account);
 
                 logger.info("Returning feedback: " + feedback.toString());
             } else {

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/db/AccountRepository.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/db/AccountRepository.java
@@ -1,0 +1,2 @@
+package com.ibm.hybrid.cloud.sample.stocktrader.account.db;public interface AccountRepository {
+}

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/db/AccountRepository.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/db/AccountRepository.java
@@ -1,2 +1,14 @@
-package com.ibm.hybrid.cloud.sample.stocktrader.account.db;public interface AccountRepository {
+package com.ibm.hybrid.cloud.sample.stocktrader.account.db;
+
+import com.ibm.hybrid.cloud.sample.stocktrader.account.json.Account;
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+import java.util.stream.Stream;
+
+
+// TODO move to PageableRepository
+@Repository
+public interface AccountRepository extends CrudRepository<Account, String> {
+    Stream<Account> findByOwner(String owner);
 }

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/json/Account.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/account/json/Account.java
@@ -17,28 +17,55 @@
 package com.ibm.hybrid.cloud.sample.stocktrader.account.json;
 
 
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+import java.util.UUID;
+
 /** JSON-B POJO class representing an Account JSON object */
+@Entity
 public class Account {
-    private String _id;
-    private String _rev;
-    private String owner;
-    private String loyalty;
-    private double balance;
-    private double commissions;
-    private int free;
-    private String sentiment;
-    private double nextCommission;
-    private String operation;
+    @Id() private String id;
+    @Column private String owner;
+    @Column private String loyalty;
+    @Column private double balance;
+    @Column private double commissions;
+    @Column private int free;
+    @Column private String sentiment;
+    @Column private double nextCommission;
+    @Column private String operation;
 
     public Account() { //default constructor
+        setId(UUID.randomUUID().toString());
+        setOwner("Someone Unknown");
+        setLoyalty("Basic");
+        setBalance(50.0);
+        setCommissions(0.0);
+        setFree(0);
+        setSentiment("Unknown");
+        setNextCommission(9.99);
     }
 
     public Account(String initialOwner) { //primary key constructor
+        this();
         setOwner(initialOwner);
     }
 
     public Account(String initialOwner, String initialLoyalty, double initialBalance, double initialCommissions,
                      int initialFree, String initialSentiment, double initialNextCommission) {
+        setId(UUID.randomUUID().toString());
+        setOwner(initialOwner);
+        setLoyalty(initialLoyalty);
+        setBalance(initialBalance);
+        setCommissions(initialCommissions);
+        setFree(initialFree);
+        setSentiment(initialSentiment);
+        setNextCommission(initialNextCommission);
+    }
+    public Account(String id, String initialOwner, String initialLoyalty, double initialBalance, double initialCommissions,
+                   int initialFree, String initialSentiment, double initialNextCommission) {
+        setId(id);
         setOwner(initialOwner);
         setLoyalty(initialLoyalty);
         setBalance(initialBalance);
@@ -48,20 +75,12 @@ public class Account {
         setNextCommission(initialNextCommission);
     }
 
-    public String get_id() {
-        return _id;
+    public String getId() {
+        return id;
     }
 
-    public void set_id(String new_id) {
-        _id = new_id;
-    }
-
-    public String get_rev() {
-        return _rev;
-    }
-
-    public void set_rev(String new_rev) {
-        _rev = new_rev;
+    public void setId(String newId) {
+        id = newId;
     }
 
     public String getOwner() {
@@ -135,8 +154,8 @@ public class Account {
    }
 
     public String toString() {
-        return "{\"_id\": \""+_id+"\", \"_rev\": \""+_rev+"\", \"owner\": \""+owner+"\", \"loyalty\": \""+loyalty
-               +"\", \"balance\": "+balance+", \"commissions\": "+commissions+", \"free\": "+free
-               +", \"nextCommission\": "+nextCommission+", \"sentiment\": \""+sentiment+"\", \"operation\": \""+operation+"\"}";
+        return "{\"_id\": \""+ id +"\", \"owner\": \""+owner+"\", \"loyalty\": \""+loyalty
+                +"\", \"balance\": "+balance+", \"commissions\": "+commissions+", \"free\": "+free
+                +", \"nextCommission\": "+nextCommission+", \"sentiment\": \""+sentiment+"\", \"operation\": \""+operation+"\"}";
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,16 +61,16 @@ watson.url=${WATSON_URL}
 watson.pwd=${WATSON_PWD}
 
 ###################
-# Cloudant config #
+# Cloudant/CouchDB config #
 ###################
-%dev.cloudant.id=<DEV CouchDB USER>
-%dev.cloudant.url=http://<DEV CouchDB USER>:<DEV CouchDB USER>@<CouchDB Host>:5984
-%dev.cloudant.password=DEV CouchDB USER Password>
-%dev.cloudant.db=account
-cloudant.id=${CLOUDANT_ID}
-cloudant.url=${CLOUDANT_URL}
-cloudant.password=${CLOUDANT_PASSWORD}
-cloudant.db=${CLOUDANT_DB:account}
+## When using the JNoSQL Lite (which does not use reflection because Quarkus + CDI Lite + Reflection = bad)
+## comment out the jnosql.document.provider or you will get reflection issues.
+#jnosql.document.provider=org.eclipse.jnosql.databases.couchdb.communication.CouchDBDocumentConfiguration
+jnosql.couchdb.host=${CLOUDANT_HOST}
+jnosql.couchdb.port=${CLOUDANT_PORT}
+jnosql.couchdb.username=${CLOUDANT_ID}
+jnosql.couchdb.password=${CLOUDANT_PASSWORD}
+jnosql.document.database=${CLOUDANT_DB:account}
 
 ##############
 # ODM Config #

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -126,6 +126,7 @@ quarkus.log.file.enable=true
 quarkus.log.file.path=/tmp/trace.log
 quarkus.log.file.level=TRACE
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
+quarkus.log.file.json=false
 # Set StockTrader package (com.ibm.hybrid) to TRACE level
 quarkus.log.min-level=TRACE
 quarkus.log.category."com.ibm.hybrid".level=TRACE


### PR DESCRIPTION
This PR replaces the [deprecated Cloudant API](https://github.com/cloudant/java-cloudant/) with [JNoSQL](https://www.jnosql.org/), a [draft JakartaEE specification](https://github.com/eclipse/jnosql) that provides an ORM to a variety of NoSQL databases, similar to what Hibernate and OpenJPA did for relational databases.

@jwalcorn I have placeholders here for two new environment variables that need to be added to the operator:

- `CLOUDANT_HOST` value to specify only the host/ip address for the CouchDB/Cloudant server
- `CLOUDANT_PORT` value to specify the port the server exposes

I am open to reusing the `CLOUDANT_URL` to get at the hostname but we need to document that it is actually just the hostname, not the fully-formed URL, that is needed here.

Moving to JNoSQL did create a minor schema change in the REST API by [removing the `_rev` field and renaming the `_id` field to `id` in the Account.java POJO](https://github.com/IBMStockTrader/account/compare/jnosql?expand=1#diff-70ebc2930564c54d947508f5cb68ed8549f14826289940b5b5524ee6e9292b5c). I have created the [corresponding PR in `broker`](https://github.com/IBMStockTrader/broker/pull/10) that ensures `broker` and `account` can communicate with each other.

